### PR TITLE
update name. ChampionScans -> ProjectTime

### DIFF
--- a/lua/modules/ComiCake.lua
+++ b/lua/modules/ComiCake.lua
@@ -58,6 +58,6 @@ end
 
 function Init()
   local cat = 'English-Scanlation'
-  AddWebsiteModule('ChampionScans', 'https://read.ptscans.com', cat)
   AddWebsiteModule('LetItGoScans', 'https://reader.letitgo.scans.today', cat)
+  AddWebsiteModule('ProjectTime', 'https://read.ptscans.com', cat)
 end


### PR DESCRIPTION
Fixing the name of the group. You can see on the site that they are now called Project Time rather then Champion Scans. 