### PR TITLE
Update HeavenManga.lua

### DIFF
--- a/lua/modules/HeavenManga.lua
+++ b/lua/modules/HeavenManga.lua
@@ -68,7 +68,11 @@ function GetPageNumber()
   if not http.Get(u) then return net_problem end
   
   x = TXQuery.Create(http.Document)
-  x.XPathStringAll('//div[@class="chapter-content"]//img/@src', task.PageLinks)
+  if x.xPath('//div[@class="chapter-content"]//img[contains(@src, "&url=")]/@src').count > 0 then
+    x.XPathStringAll('//div[@class="chapter-content"]//img/substring-after(@src, "&url=")', task.PageLinks)
+  else
+	x.XPathStringAll('//div[@class="chapter-content"]//img/@src', task.PageLinks)
+  end
   task.PageNumber = task.PageLinks.Count
   
   --[[Debug]] LuaDebug.PrintChapterPageLinks()


### PR DESCRIPTION
Fixed HeaveManga.lua to look for the direct image link if the link is a proxy link instead for example like this: `https://images2-focus-opensocial.googleusercontent.com/gadgets/proxy?container=focus&gadget=a&no_expand=1&resize_h=0&rewriteMime=image%2F*&url=https://vanbaoso0001.files.wordpress.com/2020/04/15-90.jpg`